### PR TITLE
Restore torch compilation support on CUDE and optional on MPS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,3 +65,6 @@ run-server:
 # Run GitHub Actions workflow locally with act
 act:
 	act --workflows .github/workflows/pr.yaml --job test --container-architecture linux/arm64
+
+diff-to-parent:
+	git diff parent/main -- 'nanovllm/**/*.py'

--- a/nanovllm/layers/activation.py
+++ b/nanovllm/layers/activation.py
@@ -1,6 +1,8 @@
+
 import torch
 from torch import nn
 import torch.nn.functional as F
+from nanovllm.utils.torch_compile_utils import optional_torch_compile
 
 
 class SiluAndMul(nn.Module):
@@ -14,6 +16,7 @@ class SiluAndMul(nn.Module):
         # Use nn.SiLU() to match HuggingFace exactly instead of functional
         self.act = nn.SiLU()
         
+    @optional_torch_compile
     def forward(self, x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
         # Apply activation to gate then multiply with up projection
         return self.act(x) * y

--- a/nanovllm/layers/attention.py
+++ b/nanovllm/layers/attention.py
@@ -6,6 +6,7 @@ from typing import Optional
 from .rotary_embedding import RotaryEmbedding
 from .linear import ColumnParallelLinear
 from .layernorm import RMSNorm
+from nanovllm.utils.torch_compile_utils import optional_torch_compile
 
 
 class SelfAttention(nn.Module):
@@ -53,6 +54,7 @@ class SelfAttention(nn.Module):
             base=rotary_base
         )
 
+    @optional_torch_compile
     def forward(
         self,
         hidden_states: torch.Tensor,

--- a/nanovllm/layers/layernorm.py
+++ b/nanovllm/layers/layernorm.py
@@ -1,5 +1,7 @@
+
 import torch
 from torch import nn
+from nanovllm.utils.torch_compile_utils import optional_torch_compile
 
 
 class RMSNorm(nn.Module):
@@ -14,6 +16,7 @@ class RMSNorm(nn.Module):
         self.eps = eps
         self.weight = nn.Parameter(torch.ones(hidden_size))
 
+    @optional_torch_compile
     def rms_forward(
         self,
         x: torch.Tensor,
@@ -41,6 +44,7 @@ class RMSNorm(nn.Module):
         # Apply weight and return to original dtype, exactly as HF does
         return self.weight * x.to(input_dtype)
 
+    @optional_torch_compile
     def add_rms_forward(
         self,
         x: torch.Tensor,
@@ -82,6 +86,7 @@ class RMSNorm(nn.Module):
         
         return x, residual_out
 
+    @optional_torch_compile
     def forward(
         self,
         x: torch.Tensor,

--- a/nanovllm/utils/torch_compile_utils.py
+++ b/nanovllm/utils/torch_compile_utils.py
@@ -1,0 +1,21 @@
+import os
+import torch
+
+def optional_torch_compile(fn):
+    """
+    Decorator to optionally apply torch.compile to a function based on device and environment variable.
+    Usage:
+        @optional_torch_compile
+        def forward(...):
+            ...
+    Control with env var USE_TORCH_COMPILE (default: on for CUDA, off for MPS/CPU).
+    """
+    use_compile = os.environ.get("USE_TORCH_COMPILE")
+    device = torch.device("cuda" if torch.cuda.is_available() else ("mps" if hasattr(torch.backends, 'mps') and torch.backends.mps.is_available() else "cpu"))
+    if use_compile is not None:
+        enabled = use_compile.lower() in ("1", "true", "yes", "on")
+    else:
+        enabled = device.type == "cuda"
+    if enabled and hasattr(torch, "compile"):
+        return torch.compile(fn)
+    return fn

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,8 @@ dependencies = [
     "fastapi>=0.110.0",
     "pydantic>=2.0.0",
     "uvicorn[standard]>=0.29.0",
+    # setuptools is required for torch.compile/Inductor backend (dynamic C++/CUDA compilation)
+    "setuptools",
 ]
 
 [project.urls]

--- a/uv.lock
+++ b/uv.lock
@@ -520,10 +520,16 @@ dependencies = [
     { name = "fastapi" },
     { name = "matplotlib" },
     { name = "pydantic" },
+    { name = "setuptools" },
     { name = "torch" },
     { name = "transformers" },
     { name = "uvicorn", extra = ["standard"] },
     { name = "xxhash" },
+]
+
+[package.optional-dependencies]
+torch-compile = [
+    { name = "setuptools" },
 ]
 
 [package.dev-dependencies]
@@ -539,11 +545,14 @@ requires-dist = [
     { name = "fastapi", specifier = ">=0.110.0" },
     { name = "matplotlib", specifier = ">=3.10.3" },
     { name = "pydantic", specifier = ">=2.0.0" },
+    { name = "setuptools" },
+    { name = "setuptools", marker = "extra == 'torch-compile'" },
     { name = "torch", specifier = ">=2.4.0" },
     { name = "transformers", specifier = ">=4.51.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.29.0" },
     { name = "xxhash" },
 ]
+provides-extras = ["torch-compile"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
- Introduced `optional_torch_compile` decorator to conditionally apply torch.compile based on environment variables.
- Updated `Makefile` to include a new command for diffing against parent main.
- Added `optional_torch_compile` decorator to relevant methods in activation, attention, and layer normalization layers.
- Updated `pyproject.toml` and `uv.lock` to include setuptools as a dependency for torch compilation.